### PR TITLE
feat: implement getLegalMoves function and add corresponding tests

### DIFF
--- a/src/moves/index.spec.ts
+++ b/src/moves/index.spec.ts
@@ -1,0 +1,135 @@
+import { expect, describe, it } from 'vitest';
+import { getLegalMoves } from './index';
+import { clearPosition, initBoard, placePiece } from '../board';
+import { type GameState, Color, PieceType } from '../types';
+
+describe('getLegalMoves', () => {
+  // Create a fresh game state for each test
+  const createGameState = (): GameState => ({
+    board: initBoard(),
+    currentTurn: Color.WHITE,
+    moveHistory: [],
+    isCheck: false,
+    isCheckmate: false,
+    isStalemate: false,
+  });
+
+  it('should return empty array for invalid position', () => {
+    const gameState = createGameState();
+    const moves = getLegalMoves({ col: -1, row: 5 }, gameState);
+    expect(moves).toEqual([]);
+  });
+
+  it('should return empty array for empty square', () => {
+    const gameState = createGameState();
+    // Position at e4 which is empty in initial position
+    const moves = getLegalMoves({ col: 4, row: 3 }, gameState);
+    expect(moves).toEqual([]);
+  });
+
+  it('should return pawn moves for white pawn', () => {
+    const gameState = createGameState();
+    // Position of a white pawn at e2
+    const moves = getLegalMoves({ col: 4, row: 6 }, gameState);
+
+    // Should have two moves (one square and two squares forward)
+    expect(moves.length).toBe(2);
+
+    // Check moves are correct
+    expect(moves).toContainEqual(
+      expect.objectContaining({
+        from: { col: 4, row: 6 },
+        to: { col: 4, row: 5 },
+      })
+    );
+    expect(moves).toContainEqual(
+      expect.objectContaining({
+        from: { col: 4, row: 6 },
+        to: { col: 4, row: 4 },
+        special: 'two-square-advance',
+      })
+    );
+  });
+
+  it('should return knight moves for white knight', () => {
+    const gameState = createGameState();
+    // Position of a white knight at b1
+    const moves = getLegalMoves({ col: 1, row: 7 }, gameState);
+
+    // Knight at initial position can move to a3 and c3
+    expect(moves.length).toBe(2);
+
+    // Check moves are correct
+    expect(moves).toContainEqual(
+      expect.objectContaining({
+        from: { col: 1, row: 7 },
+        to: { col: 0, row: 5 },
+      })
+    );
+    expect(moves).toContainEqual(
+      expect.objectContaining({
+        from: { col: 1, row: 7 },
+        to: { col: 2, row: 5 },
+      })
+    );
+  });
+
+  it('should prevent capturing own pieces', () => {
+    const gameState = createGameState();
+
+    // Clear the board
+    for (let row = 0; row < 8; row++) {
+      for (let col = 0; col < 8; col++) {
+        clearPosition(gameState.board, { col, row });
+      }
+    }
+
+    // Place a white king at e4
+    placePiece(gameState.board, { col: 4, row: 3 }, { type: PieceType.KING, color: Color.WHITE });
+
+    // Place a white pawn at e5 (in front of the king)
+    placePiece(gameState.board, { col: 4, row: 2 }, { type: PieceType.PAWN, color: Color.WHITE });
+
+    // Get legal moves for the king
+    const moves = getLegalMoves({ col: 4, row: 3 }, gameState);
+
+    // King can move to all 8 surrounding squares except e5 (occupied by own pawn)
+    expect(moves.length).toBe(7);
+
+    // Make sure there's no move to e5
+    expect(moves.some((move) => move.to.col === 4 && move.to.row === 2)).toBe(false);
+  });
+
+  it('should allow capturing opponent pieces', () => {
+    const gameState = createGameState();
+
+    // Clear the board
+    for (let row = 0; row < 8; row++) {
+      for (let col = 0; col < 8; col++) {
+        clearPosition(gameState.board, { col, row });
+      }
+    }
+
+    // Place a white bishop at e4
+    placePiece(gameState.board, { col: 4, row: 3 }, { type: PieceType.BISHOP, color: Color.WHITE });
+
+    // Place a black pawn at g6 (diagonal to the bishop)
+    placePiece(gameState.board, { col: 6, row: 1 }, { type: PieceType.PAWN, color: Color.BLACK });
+
+    console.log('Bishop position:', { col: 4, row: 3 });
+    console.log('Pawn position:', { col: 6, row: 1 });
+
+    // Get legal moves for the bishop
+    const moves = getLegalMoves({ col: 4, row: 3 }, gameState);
+    console.log('Available moves:', JSON.stringify(moves, null, 2));
+
+    // Check that capture move exists
+    const captureMove = moves.find((move) => move.to.col === 6 && move.to.row === 1);
+    expect(captureMove).toBeDefined();
+    expect(captureMove?.capture).toBe(true);
+  });
+
+  // TODO: Add tests for castling, en passant, promotion, etc.
+
+  // TODO: Add tests for check and checkmate
+});

--- a/src/moves/index.spec.ts
+++ b/src/moves/index.spec.ts
@@ -116,12 +116,8 @@ describe('getLegalMoves', () => {
     // Place a black pawn at g6 (diagonal to the bishop)
     placePiece(gameState.board, { col: 6, row: 1 }, { type: PieceType.PAWN, color: Color.BLACK });
 
-    console.log('Bishop position:', { col: 4, row: 3 });
-    console.log('Pawn position:', { col: 6, row: 1 });
-
     // Get legal moves for the bishop
     const moves = getLegalMoves({ col: 4, row: 3 }, gameState);
-    console.log('Available moves:', JSON.stringify(moves, null, 2));
 
     // Check that capture move exists
     const captureMove = moves.find((move) => move.to.col === 6 && move.to.row === 1);

--- a/src/moves/index.ts
+++ b/src/moves/index.ts
@@ -1,0 +1,87 @@
+import type { GameState, Move, Position } from '../types';
+import { PieceType } from '../types';
+import { getPieceAt, isValidPosition } from '../board';
+import { getPawnMoves } from './pawn';
+import { getRookMoves } from './rook';
+import { getKnightMoves } from './knight';
+import { getBishopMoves } from './bishop';
+import { getQueenMoves } from './queen';
+import { getKingMoves } from './king';
+
+/**
+ * Returns all legal moves for the piece at the given position.
+ * This function acts as a dispatcher that routes to piece-specific movement logic.
+ *
+ * @param position The position of the piece
+ * @param gameState The current game state
+ * @returns An array of legal moves for the piece
+ */
+export const getLegalMoves = (position: Position, gameState: GameState): Move[] => {
+  // Check if position is valid
+  if (!isValidPosition(position)) {
+    return [];
+  }
+
+  // Get the piece at the position
+  const piece = getPieceAt(position, gameState.board);
+
+  // If there's no piece at the position, return empty array
+  if (!piece) {
+    return [];
+  }
+
+  // Dispatch to the appropriate piece-specific function based on the piece type
+  switch (piece.type) {
+    case PieceType.PAWN:
+      return getPawnMoves(position, gameState);
+
+    case PieceType.ROOK:
+      return getRookMoves(position, gameState);
+
+    case PieceType.KNIGHT: {
+      // Knight has a different function signature, so we need to adapt it
+      const knightPositions = getKnightMoves(position);
+
+      // Convert positions to moves and filter friendly fire
+      return knightPositions.flatMap((to) => {
+        const targetPiece = getPieceAt(to, gameState.board);
+
+        // Don't allow capturing own pieces
+        if (targetPiece && targetPiece.color === piece.color) {
+          return [];
+        }
+
+        return [
+          {
+            from: position,
+            to,
+            capture: targetPiece !== null,
+          },
+        ];
+      });
+    }
+
+    case PieceType.BISHOP:
+      return getBishopMoves(position, gameState);
+
+    case PieceType.QUEEN:
+      return getQueenMoves(position, gameState);
+
+    case PieceType.KING:
+      return getKingMoves(position, gameState);
+
+    default:
+      console.error(`Unknown piece type: ${piece.type}`);
+      return [];
+  }
+};
+
+/**
+ * Exports all move-related functions
+ */
+export * from './pawn';
+export * from './rook';
+export * from './knight';
+export * from './bishop';
+export * from './queen';
+export * from './king';


### PR DESCRIPTION
close #9 

- Added the getLegalMoves function to determine legal moves for pieces based on their type.
- Implemented tests for various scenarios including invalid positions, empty squares, and specific piece movements (pawns, knights).
- Included checks for capturing own pieces and allowing captures of opponent pieces.
- Set up a testing framework using Vitest for the new functionality.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
  - 체스판의 특정 위치에서 가능한 모든 합법적인 이동을 반환하는 기능이 추가되었습니다.
- **테스트**
  - 다양한 체스 상황에서 합법적인 이동을 검증하는 테스트가 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->